### PR TITLE
SHACL validations examples

### DIFF
--- a/examples-SHACL-validations/Initial-Example-Resource.jsonld
+++ b/examples-SHACL-validations/Initial-Example-Resource.jsonld
@@ -1,0 +1,153 @@
+{
+  "@context": {
+    "ids": "https://w3id.org/idsa/core/",
+    "idsc": "https://w3id.org/idsa/code/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "odrl": "http://www.w3.org/ns/odrl/2/",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "dct": "http://purl.org/dc/terms/",
+    "time": "http://www.w3.org/2006/time#",
+    "conn3": "https://aastat.gov.de/connector/conn3/",
+    "data3": "https://aastat.gov.de/connector/conn3/data3/",
+    "part1": "https://im.internationaldataspaces.org/participant/part1"
+  },
+  "@graph": [
+    {
+      "@id": "data3:",
+      "@type": "ids:TextResource",
+      "ids:title": {
+        "@value": "European highway statistics - traffic report",
+        "@language": "en"
+      },
+      "ids:description": {
+        "@value": "Detailed traffic analysis report based on European highway statistics data 2000 - 2017.",
+        "@language": "en"
+      },
+      "ids:keyword": [
+        "report",
+        "highway",
+        "statistics",
+        "Europe"
+      ],
+      "dct:temporal": {
+        "@type": "ids:Interval",
+        "time:hasBeginning": {
+          "@type": "time:Instant",
+          "time:inXSDDateTimeStamp": {
+            "@value": "2001-01-01T12:00:00.000+02:00",
+            "@type": "xsd:dateTimeStamp"
+          }
+        },
+        "time:hasEnd": {
+          "@type": "time:Instant",
+          "time:inXSDDateTimeStamp": {
+            "@value": "2017-12-31T12:00:00.000+02:00",
+            "@type": "xsd:dateTimeStamp"
+          }
+        }
+      },
+      "ids:language": {
+        "@id": "idsc:EN"
+      },
+      "ids:representation": [
+        {
+          "@type": "ids:TextRepresentation",
+          "ids:mediaType": {
+            "@id": "https://www.iana.org/assignments/media-types/application/pdf"
+          },
+          "ids:instance": {
+            "@id": "data3:report_pdf"
+          }
+        },
+        {
+          "@type": "ids:TextRepresentation",
+          "ids:mediaType": {
+            "@id": "https://www.iana.org/assignments/media-types/application/msword"
+          },
+          "ids:instance": {
+            "@id": "data3:report_doc"
+          }
+        }
+      ],
+      "ids:resourceEndpoint": [
+        {
+          "@type": "ids:ConnectorEndpoint",
+          "ids:endpointArtifact": {
+            "@id": "data3:report_pdf"
+          },
+          "ids:accessURL": {
+            "@id": "https://connector.aastat.gov.de/reports/Highway_traffic_statistics.pdf"
+          }
+        },
+        {
+          "@type": "ids:ConnectorEndpoint",
+          "ids:endpointArtifact": {
+            "@id": "data3:report_doc"
+          },
+          "ids:accessURL": {
+            "@id": "https://connector.aastat.gov.de/reports/Highway_traffic_statistics.doc"
+          }
+        }
+      ],
+      "ids:contractOffer": {
+        "@id": "data3:offer"
+      }
+    },
+    {
+      "@id": "data3:report_pdf",
+      "@type": "ids:Artifact",
+      "ids:byteSize": 1923497,
+      "ids:fileName": "Highway_traffic_statistics.pdf",
+      "ids:creationDate": {
+        "@value": "2018-06-18T12:00:00.000+02:00",
+        "@type": "xsd:dateTimeStamp"
+      }
+    },
+    {
+      "@id": "data3:report_doc",
+      "@type": "ids:Artifact",
+      "ids:byteSize": 28923491,
+      "ids:fileName": "Highway_traffic_statistics.doc",
+      "ids:creationDate": {
+        "@value": "2018-06-18T12:00:00.000+02:00",
+        "@type": "xsd:dateTimeStamp"
+      }
+    },
+    {
+      "@id": "data3:offer",
+      "@type": "ids:ContractOffer",
+      "ids:permission": {
+        "@type": "ids:Permission",
+        "ids:assigner": {
+          "@id": "part1:"
+        },
+        "ids:target": {
+          "@id": "data3:"
+        },
+        "odrl:action": {
+          "@id": "idsc:USE"
+        },
+        "ids:constraint": {
+          "@type": "ids:Constraint",
+          "odrl:leftOperand": {
+            "@id": "idsc:SECURITY_LEVEL"
+          },
+          "odrl:operator": {
+            "@id": "idsc:GTEQ"
+          },
+          "odrl:rightOperand": {
+            "@id": "idsc:TRUST_SECURITY_PROFILE"
+          }
+        }
+      }
+    },
+    {
+      "@id": "https://www.iana.org/assignments/media-types/application/pdf",
+      "@type": "ids:IANAMediaType"
+    },
+    {
+      "@id": "https://www.iana.org/assignments/media-types/application/msword",
+      "@type": "ids:IANAMediaType"
+    }
+  ]
+}

--- a/examples-SHACL-validations/basicIDSValidations/basicExampleResource-ExternalReferences.ttl
+++ b/examples-SHACL-validations/basicIDSValidations/basicExampleResource-ExternalReferences.ttl
@@ -1,0 +1,91 @@
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix ids: <https://w3id.org/idsa/core/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+@prefix data3: <https://aastat.gov.de/connector/conn3/data3/> .
+@prefix idsc: <https://w3id.org/idsa/code/> .
+@prefix part1: <https://im.internationaldataspaces.org/participant/part1> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+data3:
+  a <https://w3id.org/idsa/core/TextResource> ;
+  dct:temporal [
+    a <https://w3id.org/idsa/core/Interval> ;
+    time:hasBeginning [
+      a time:Instant ;
+      ids:dateTime "2001-01-01T12:00:00-05:00"^^xsd:dateTime
+    ] ;
+    time:hasEnd [
+      a time:Instant ;
+      ids:dateTime "2017-12-31T12:00:00-05:00"^^xsd:dateTime
+    ]
+  ] ;
+  ids:contractOffer data3:offer;                   
+  dct:description "Detailed traffic analysis report based on European highway statistics data 2000 - 2017."@en ;
+  dct:keyword "report"^^xsd:string, "highway"^^xsd:string, "statistics"^^xsd:string, "Europe"^^xsd:string ;
+  dct:language idsc:EN ;
+  ids:representation [
+        a ids:TextRepresentation ;
+        dcat:mediaType <https://www.iana.org/assignments/media-types/application/pdf> ;
+        ids:instance data3:report_pdf ;
+    ] ;
+    ids:representation [
+        a ids:TextRepresentation ;
+        dcat:mediaType <https://www.iana.org/assignments/media-types/application/msword> ;
+        ids:instance data3:report_doc ;
+    ] ;
+  ids:resourceEndpoint [
+    a ids:ConnectorEndpoint ;
+    ids:accessURL <https://connector.aastat.gov.de/reports/Highway_traffic_statistics.pdf> ;
+    ids:endpointArtifact data3:report_pdf
+  ], [
+    a ids:ConnectorEndpoint ;
+    ids:accessURL <https://connector.aastat.gov.de/reports/Highway_traffic_statistics.doc> ;
+    ids:endpointArtifact data3:report_doc
+  ] ;
+  dct:title "European highway statistics - traffic report"@en .
+
+data3:offer
+  a ids:ContractOffer ;
+  ids:contractStart "2021-10-10T12:00:00-05:00"^^xsd:dateTime ;
+  ids:contractEnd      "2022-06-01T12:00:00-05:00"^^xsd:dateTime ;
+  ids:provider         <http://iml.fraunhofer.de> ;
+  ids:contractDocument data3:;
+  odrl:permission data3:permission .
+
+data3:report_pdf
+  a ids:Artifact ;
+  ids:byteSize "28923491"^^xsd:integer ;
+  dct:created "2018-06-18T12:00:00.000+02:00"^^xsd:dateTimeStamp ;
+  ids:fileName "Highway_traffic_statistics.pdf"^^xsd:string .
+
+data3:report_doc
+    a ids:Artifact ;
+    ids:byteSize "28923491"^^xsd:integer ;
+    ids:fileName "Highway_traffic_statistics.doc" ;
+    dct:created "2018-06-18T12:00:00.000+02:00"^^xsd:dateTimeStamp ;
+    .
+
+data3:permission a odrl:Permission ;
+    odrl:action  data3:action;
+    ids:target data3: ;
+    ids:assigner <https://im.internationaldataspaces.org/participant/part1> ;
+    odrl:constraint data3:constraint .
+
+<https://www.iana.org/assignments/media-types/application/pdf> a ids:IANAMediaType .
+<https://www.iana.org/assignments/media-types/application/msword> a ids:IANAMediaType .
+
+ids:IANAMediaType rdfs:subClassOf dct:MediaType .
+idsc:EN a ids:Language .
+
+idsc:READ a data3:action .
+data3:action a odrl:Action .
+
+data3:constraint
+      a odrl:Constraint ;
+      ids:leftOperand idsc:DELAY ;
+      ids:operator idsc:LONGER ;
+      ids:rightOperand "PT20M"^^xsd:duration .
+

--- a/examples-SHACL-validations/basicIDSValidations/basicExampleResource-LocalReferences.ttl
+++ b/examples-SHACL-validations/basicIDSValidations/basicExampleResource-LocalReferences.ttl
@@ -1,0 +1,81 @@
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix ids: <https://w3id.org/idsa/core/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+@prefix data3: <https://aastat.gov.de/connector/conn3/data3/> .
+@prefix idsc: <https://w3id.org/idsa/code/> .
+@prefix part1: <https://im.internationaldataspaces.org/participant/part1> .
+
+data3:
+  a <https://w3id.org/idsa/core/TextResource> ;
+  dct:temporal [
+    a <https://w3id.org/idsa/core/Interval> ;
+    ids:begin [
+      a ids:Instant ;
+      ids:dateTime "2001-01-01T12:00:00-05:00"^^xsd:dateTime
+    ] ;
+    ids:end [
+      a ids:Instant ;
+      ids:dateTime "2017-12-31T12:00:00-05:00"^^xsd:dateTime
+    ]
+  ] ;
+  ids:contractOffer data3:offer;                   
+  ids:description "Detailed traffic analysis report based on European highway statistics data 2000 - 2017."@en ;
+  ids:keyword "report"^^xsd:string, "highway"^^xsd:string, "statistics"^^xsd:string, "Europe"^^xsd:string ;
+  ids:language idsc:EN ;
+  ids:representation [
+        a ids:TextRepresentation ;
+        ids:mediaType <https://www.iana.org/assignments/media-types/application/pdf> ;
+        ids:instance data3:report_pdf ;
+    ] ;
+    ids:representation [
+        a ids:TextRepresentation ;
+        ids:mediaType <https://www.iana.org/assignments/media-types/application/msword> ;
+        ids:instance data3:report_doc ;
+    ] ;
+  ids:resourceEndpoint [
+    a ids:ConnectorEndpoint ;
+    ids:accessURL <https://connector.aastat.gov.de/reports/Highway_traffic_statistics.pdf> ;
+    ids:endpointArtifact data3:report_pdf
+  ], [
+    a ids:ConnectorEndpoint ;
+    ids:accessURL <https://connector.aastat.gov.de/reports/Highway_traffic_statistics.doc> ;
+    ids:endpointArtifact data3:report_doc
+  ] ;
+  ids:title "European highway statistics - traffic report"@en .
+
+data3:offer
+  a ids:ContractOffer ;
+  ids:contractStart "2021-10-10T12:00:00-05:00"^^xsd:dateTime ;
+  ids:contractEnd      "2022-06-01T12:00:00-05:00"^^xsd:dateTime ;
+  ids:provider         <http://iml.fraunhofer.de> ;
+  ids:contractDocument data3:;
+  ids:permission [
+    a ids:Permission ;
+    ids:action     idsc:READ;
+    ids:target data3: ;
+    ids:assigner <https://im.internationaldataspaces.org/participant/part1> ;
+    ids:constraint [
+      a ids:AbstractConstraint ;
+      ids:leftOperand idsc:DELAY ;
+      ids:operator idsc:LONGER ;
+      ids:rightOperand "PT20M"^^xsd:duration
+    ] ;
+  ] .
+
+data3:report_pdf
+  a ids:Artifact ;
+  ids:byteSize "28923491"^^xsd:integer ;
+  ids:creationDate "2018-06-18T12:00:00.000+02:00"^^xsd:dateTimeStamp ;
+  ids:fileName "Highway_traffic_statistics.pdf"^^xsd:string .
+
+data3:report_doc
+    a ids:Artifact ;
+    ids:byteSize "28923491"^^xsd:integer ;
+    ids:fileName "Highway_traffic_statistics.doc" ;
+    ids:creationDate "2018-06-18T12:00:00.000+02:00"^^xsd:dateTimeStamp ;
+    .
+
+<https://www.iana.org/assignments/media-types/application/pdf> a ids:IANAMediaType .
+<https://www.iana.org/assignments/media-types/application/msword> a ids:IANAMediaType .
+

--- a/examples-SHACL-validations/basicIDSValidations/basicIDSValidation-ExternalReferences.ttl
+++ b/examples-SHACL-validations/basicIDSValidations/basicIDSValidation-ExternalReferences.ttl
@@ -1,0 +1,399 @@
+# baseURI: http://fit.fraunhofer.de/ap15/constraints
+# imports: http://datashapes.org/dash
+# imports: http://purl.org/dc/elements/1.1/
+# imports: http://purl.org/dc/terms/
+# prefix: ap15
+
+#Basic IDS validation, using validations specificed in the develop brach of the IDS Infomodel (after refactor to reference external specifications) https://github.com/International-Data-Spaces-Association/InformationModel/tree/develop/testing
+
+@prefix ap15: <http://fit.fraunhofer.de/ap15/constraints#> .
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ids: <https://w3id.org/idsa/core/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix p1: <http://xmlns.com/foaf/0.1/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+
+<http://fit.fraunhofer.de/ap15/constraints>
+  a owl:Ontology ;
+  owl:imports <http://datashapes.org/dash> ;
+  owl:imports <http://purl.org/dc/elements/1.1/> ;
+  owl:imports <http://purl.org/dc/terms/> ;
+  owl:versionInfo "Created with TopBraid Composer" ;
+  sh:declare ids:PrefixDeclaration ;
+.
+ap15:ConnectorEndpointShape
+  a rdfs:Class ;
+  a sh:NodeShape ;
+sh:targetClass ids:ConnectorEndpoint ;
+  rdfs:label "Connector endpoint shape" ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:accessURL ;
+      sh:nodeKind sh:IRI ;
+      sh:minCount 1 ;
+      sh:maxCount 1;
+      sh:name "access URL" ;
+    ] ;
+sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:endpointArtifact ;
+		sh:class ids:Artifact ;
+		sh:maxCount 1 ;
+	] ;
+.
+
+ap15:ArtifactShape
+	a sh:NodeShape ;
+	sh:targetClass ids:Artifact ;
+
+	sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:byteSize ;
+		sh:datatype xsd:integer ;
+        sh:minInclusive 0 ;
+		sh:maxCount 1 ;
+	] ;
+
+
+	sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:fileName ;
+		sh:datatype xsd:string ;
+		sh:maxCount 1 ;
+	] ;
+
+	sh:property [
+		a sh:PropertyShape ;
+		sh:path dct:created ;
+		sh:datatype xsd:dateTimeStamp ;
+		sh:maxCount 1 ;
+	] ;
+
+	sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:checkSum ;
+		sh:datatype xsd:string ;
+		sh:maxCount 1 ;
+	] ;
+
+	sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:duration ;
+		sh:datatype xsd:decimal ;
+		sh:maxCount 1 ;
+	] .
+
+
+ap15:ResourceShape
+  a rdfs:Class ;
+  a sh:NodeShape ;
+  rdfs:label "Resource shape" ;
+  sh:targetClass ids:Resource;
+  sh:property [
+		a sh:PropertyShape ;
+		sh:path dct:description ;
+		sh:or (
+            [
+                sh:datatype xsd:string ;
+			]
+			[
+                sh:datatype rdf:langString ;
+            ]
+            );
+	] ;
+sh:property [
+		a sh:PropertyShape ;
+		sh:path dct:title ;
+    sh:or (
+            [
+                sh:datatype xsd:string ;
+			]
+			[
+                sh:datatype rdf:langString ;
+            ]
+            );
+	] ;
+
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path dct:issued ;
+      sh:datatype xsd:dateTime ;
+      sh:maxCount 1 ;
+      sh:name "created" ;
+    ] ;
+	sh:property [
+		a sh:PropertyShape ;
+		sh:path dcat:keyword ;
+		sh:or (
+            [
+                sh:datatype xsd:string ;
+			]
+			[
+                sh:datatype rdf:langString ;
+            ]
+    );
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path dct:modified ;
+      sh:datatype xsd:dateTime ;
+      sh:maxCount 1 ;
+      sh:name "modified" ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path dct:publisher ;
+      sh:or (
+	    [ sh:class foaf:Agent ; sh:order 1 ; ]
+	    [ sh:nodeKind sh:IRI ; sh:order 2 ; ]
+		) ;
+      sh:maxCount 1 ;
+      sh:name "publisher" ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:resourceEndpoint ;
+      sh:name "resource endpoint" ;
+      sh:node ap15:ConnectorEndpointShape ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:resourcePart ;
+      sh:class ids:Resource ;
+      sh:name "resource part" ;
+      sh:node ap15:ResourceShape ;
+    ] ;
+  sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:resourceInterface ;
+		sh:class ids:Interface ;
+	] ;
+  sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:sovereign ;
+		sh:or (
+	    [ sh:class foaf:Agent ; sh:order 1 ; ]
+	    [ sh:nodeKind sh:IRI ; sh:order 2 ; ]
+		) ;
+		sh:maxCount 1 ;
+	] ;
+   sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:contractOffer ;
+		sh:node ap15:ContractOfferShape ;
+	] ;
+    sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:sample ;
+		sh:class ids:Resource ;
+	] ;
+    sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:variant ;
+		sh:class ids:Resource ;
+		sh:maxCount 1 ;
+	];
+.
+
+ap15:ContractOfferShape
+  a rdfs:Class ;
+  a sh:NodeShape ;
+  sh:targetClass ids:ContractOffer;
+  rdfs:label "Contract offer shape" ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:contractDocument ;
+      sh:class ids:TextResource ;
+      sh:name "contract document" ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:contractEnd ;
+      sh:datatype xsd:dateTime ;
+      sh:maxCount 1 ;
+      sh:name "contract end" ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:contractStart ;
+      sh:datatype xsd:dateTime ;
+      sh:maxCount 1 ;
+      sh:minCount 1 ;
+      sh:name "contract start" ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path odrl:permission ;
+      sh:class odrl:Permission ;
+      sh:name "permission" ;
+      sh:node ap15:PermissionShape ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:provider ;
+      sh:nodeKind sh:IRI ;
+      sh:pattern "^(?:(http(s)?|idscp|(s)?ftp))";
+      sh:maxCount 1 ;
+      sh:name "provider" ;
+    ] ;
+.
+ap15:InstantShape
+  a rdfs:Class ;
+  a sh:NodeShape ;
+  sh:targetClass time:Instant;
+  rdfs:label "Instant shape" ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path time:inXSDDateTimeStamp ;
+      sh:datatype xsd:dateTimeStamp ;
+      sh:maxCount 1 ;
+      sh:name "date time" ;
+    ] ;
+.
+ap15:PermissionShape
+  a rdfs:Class ;
+  a sh:NodeShape ;
+  sh:targetClass odrl:Permission;
+  rdfs:label "Permission shape" ;
+  sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:preDuty ;
+		sh:class odrl:Duty ;
+	] ;
+
+	sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:postDuty ;
+		sh:class odrl:Duty ;
+	] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path odrl:action ;
+      sh:class odrl:Action ;
+      sh:minCount 1 ;
+      sh:name "action" ;
+    ] ;
+    sh:property [
+		a sh:PropertyShape ;
+		sh:path odrl:assignee ;
+        sh:nodeKind sh:IRI ;
+		sh:minCount 0 ;
+	] ;
+sh:property [
+		a sh:PropertyShape ;
+		sh:path odrl:assigner ;
+        sh:nodeKind sh:IRI ; 
+		sh:minCount 0 ;
+	] ;
+sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:target ;
+        sh:nodeKind sh:IRI ;
+		sh:maxCount 1 ;
+	] ;
+sh:property [
+		a sh:PropertyShape ;
+		sh:path odrl:refinement ;
+		sh:class odrl:Constraint ;
+		sh:maxCount 1 ;
+	] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path odrl:constraint ;
+      sh:class odrl:Constraint ;
+      sh:name "constraint" ;
+    ] ;
+.
+ap15:RepresentationShape
+  a rdfs:Class ;
+  a sh:NodeShape ;
+  sh:targetClass ids:TextRepresentation;
+  rdfs:label "Representation shape" ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path dct:accrualPeriodicity ;
+      sh:class ids:Frequency ;
+      sh:maxCount 1 ;
+      sh:name "accrual periodicity" ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:dataTypeSchema ;
+      sh:class ids:Resource ;
+      sh:maxCount 1 ;
+      sh:name "data type schema" ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path dcat:mediaType ;
+      sh:class dct:MediaType ;
+      sh:maxCount 1 ;
+      sh:name "media type" ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path dct:temporal ;
+      sh:class time:TemporalEntity ;
+      sh:name "temporal coverage" ;
+      sh:node ap15:TemporalCoverageShape ;
+    ] ;
+.
+
+ap15:TemporalCoverageShape
+  a rdfs:Class ;
+  a sh:NodeShape ;
+  sh:targetClass time:Interval;
+  rdfs:label "Temporal coverage shape" ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path time:hasBeginning ;
+      sh:class time:Instant;
+      sh:maxCount 1 ;
+      sh:minCount 1 ;
+      sh:name "begin" ;
+      sh:node ap15:InstantShape ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path time:hasEnd ;
+      sh:class time:Instant ;
+      sh:maxCount 1 ;
+      sh:name "end" ;
+      sh:node ap15:InstantShape ;
+    ] ;
+.
+ap15:TextResourceShape
+    a sh:NodeShape;
+    sh:targetClass ids:TextResource;
+    sh:property [
+                    a sh:PropertyShape ;
+                    sh:path ids:representation ;
+                    sh:class ids:TextRepresentation ;
+                ] ;
+
+    sh:property [
+                    a sh:PropertyShape ;
+                    sh:path ids:defaultRepresentation ;
+                    sh:class ids:TextRepresentation ;
+                ] ;
+    sh:property [
+		a sh:PropertyShape ;
+		sh:path dct:language ;
+		sh:class ids:Language ;
+	] ;
+
+.
+
+ids:PrefixDeclaration
+  a sh:PrefixDeclaration ;
+  sh:namespace "https://w3id.org/idsa/core/"^^xsd:anyURI ;
+  sh:prefix "ids" ;
+.

--- a/examples-SHACL-validations/basicIDSValidations/basicIDSValidation-LocalReferences.ttl
+++ b/examples-SHACL-validations/basicIDSValidations/basicIDSValidation-LocalReferences.ttl
@@ -1,0 +1,407 @@
+# baseURI: http://fit.fraunhofer.de/ap15/constraints
+# imports: http://datashapes.org/dash
+# imports: http://purl.org/dc/elements/1.1/
+# imports: http://purl.org/dc/terms/
+# prefix: ap15
+
+#Basic IDS validation, using validations specificed in the main brach of the IDS Infomodel (before refactor to reference external specifications) https://github.com/International-Data-Spaces-Association/InformationModel/tree/main/testing
+
+@prefix ap15: <http://fit.fraunhofer.de/ap15/constraints#> .
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ids: <https://w3id.org/idsa/core/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix p1: <http://xmlns.com/foaf/0.1/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://fit.fraunhofer.de/ap15/constraints>
+  a owl:Ontology ;
+  owl:imports <http://datashapes.org/dash> ;
+  owl:imports <http://purl.org/dc/elements/1.1/> ;
+  owl:imports <http://purl.org/dc/terms/> ;
+  owl:versionInfo "Created with TopBraid Composer" ;
+  sh:declare ids:PrefixDeclaration ;
+.
+ap15:ConnectorEndpointShape
+  a rdfs:Class ;
+  a sh:NodeShape ;
+sh:targetClass ids:ConnectorEndpoint ;
+  rdfs:label "Connector endpoint shape" ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:accessURL ;
+      sh:nodeKind sh:IRI ;
+      sh:minCount 1 ;
+      sh:maxCount 1;
+      sh:name "access URL" ;
+    ] ;
+sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:endpointArtifact ;
+		sh:class ids:Artifact ;
+		sh:maxCount 1 ;
+	] ;
+.
+
+ap15:ArtifactShape
+	a sh:NodeShape ;
+	sh:targetClass ids:Artifact ;
+
+	sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:byteSize ;
+		sh:datatype xsd:integer ;
+        sh:minInclusive 0 ;
+		sh:maxCount 1 ;
+	] ;
+
+
+	sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:fileName ;
+		sh:datatype xsd:string ;
+		sh:maxCount 1 ;
+	] ;
+
+	sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:creationDate ;
+		sh:datatype xsd:dateTimeStamp ;
+		sh:maxCount 1 ;
+	] ;
+
+	sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:artifactParameterization ;
+		sh:class ids:ParameterAssignment ;
+	] ;
+
+	sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:checkSum ;
+		sh:datatype xsd:string ;
+		sh:maxCount 1 ;
+	] ;
+
+	sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:duration ;
+		sh:datatype xsd:decimal ;
+		sh:maxCount 1 ;
+	] .
+
+
+ap15:ResourceShape
+  a rdfs:Class ;
+  a sh:NodeShape ;
+  rdfs:label "Resource shape" ;
+  sh:targetClass ids:Resource;
+  sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:description ;
+		sh:or (
+            [
+                sh:datatype xsd:string ;
+			]
+			[
+                sh:datatype rdf:langString ;
+            ]
+            );
+	] ;
+sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:title ;
+    sh:or (
+            [
+                sh:datatype xsd:string ;
+			]
+			[
+                sh:datatype rdf:langString ;
+            ]
+            );
+	] ;
+
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:created ;
+      sh:datatype xsd:dateTime ;
+      sh:maxCount 1 ;
+      sh:name "created" ;
+    ] ;
+	sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:keyword ;
+		sh:or (
+            [
+                sh:datatype xsd:string ;
+			]
+			[
+                sh:datatype rdf:langString ;
+            ]
+    );
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:modified ;
+      sh:datatype xsd:dateTime ;
+      sh:maxCount 1 ;
+      sh:name "modified" ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:publisher ;
+      sh:nodeKind sh:IRI ;
+      sh:maxCount 1 ;
+      sh:name "publisher" ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:resourceEndpoint ;
+      sh:name "resource endpoint" ;
+      sh:node ap15:ConnectorEndpointShape ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:resourcePart ;
+      sh:class ids:Resource ;
+      sh:name "resource part" ;
+      sh:node ap15:ResourceShape ;
+    ] ;
+  sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:resourceInterface ;
+		sh:class ids:Interface ;
+	] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:sovereign ;
+      sh:nodeKind sh:IRI ;
+      sh:maxCount 1 ;
+      sh:name "sovereign" ;
+    ] ;
+   sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:contractOffer ;
+		sh:node ap15:ContractOfferShape ;
+	] ;
+    sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:sample ;
+		sh:class ids:Resource ;
+	] ;
+    sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:variant ;
+		sh:class ids:Resource ;
+		sh:maxCount 1 ;
+	];
+.
+
+ap15:ContractOfferShape
+  a rdfs:Class ;
+  a sh:NodeShape ;
+  sh:targetClass ids:ContractOffer;
+  rdfs:label "Contract offer shape" ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:contractDocument ;
+      sh:class ids:TextResource ;
+      sh:name "contract document" ;
+      sh:maxCount 1 ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:contractEnd ;
+      sh:datatype xsd:dateTime ;
+      sh:maxCount 1 ;
+      sh:name "contract end" ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:contractStart ;
+      sh:datatype xsd:dateTime ;
+      sh:minCount 1 ;
+      sh:maxCount 1 ;
+      sh:name "contract start" ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:permission ;
+      sh:class ids:Permission ;
+      sh:name "permission" ;
+      sh:node ap15:PermissionShape ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:provider ;
+      sh:nodeKind sh:IRI ;
+      sh:pattern "^(?:(http(s)?|idscp|(s)?ftp))";
+      sh:maxCount 1 ;
+      sh:name "provider" ;
+    ] ;
+.
+ap15:InstantShape
+  a rdfs:Class ;
+  a sh:NodeShape ;
+  sh:targetClass ids:Instant;
+  rdfs:label "Instant shape" ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:dateTime ;
+      sh:datatype xsd:dateTime ;
+      sh:maxCount 1 ;
+      sh:minCount 1 ;
+      sh:name "date time" ;
+    ] ;
+.
+ap15:PermissionShape
+  a rdfs:Class ;
+  a sh:NodeShape ;
+  sh:targetClass ids:Permission;
+  rdfs:label "Permission shape" ;
+  sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:preDuty ;
+		sh:class ids:Duty ;
+	] ;
+
+	sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:postDuty ;
+		sh:class ids:Duty ;
+	] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:action ;
+      sh:minCount 1 ;
+      sh:name "action" ;
+    ] ;
+    sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:assignee ;
+		sh:or (
+      [ sh:nodeKind sh:IRI ; ]
+			[ sh:class ids:Participant ; ]
+    );
+		sh:minCount 0 ;
+	] ;
+sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:assigner ;
+		sh:or (
+      [ sh:nodeKind sh:IRI ; ]
+			[ sh:class ids:Participant ; ]
+    );
+		sh:minCount 0 ;
+	] ;
+sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:target ;
+		sh:or (
+      [ sh:nodeKind sh:IRI ; ]
+			[ sh:class ids:Asset ; ]
+    );
+		sh:maxCount 1 ;
+	] ;
+sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:assetRefinement ;
+		sh:class ids:AbstractConstraint ;
+		sh:maxCount 1 ;
+	] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:constraint ;
+      sh:class ids:AbstractConstraint ;
+      sh:name "constraint" ;
+    ] ;
+.
+ap15:RepresentationShape
+  a rdfs:Class ;
+  a sh:NodeShape ;
+  sh:targetClass ids:TextRepresentation;
+  rdfs:label "Representation shape" ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:accrualPeriodicity ;
+      sh:class ids:Frequency ;
+      sh:maxCount 1 ;
+      sh:name "accrual periodicity" ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:dataTypeSchema ;
+      sh:class ids:Resource ;
+      sh:maxCount 1 ;
+      sh:name "data type schema" ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:mediaType ;
+      sh:or (
+            [
+                sh:class ids:MediaType ;
+			]
+			[
+                sh:class ids:IANAMediaType ;
+            ]
+            );
+      sh:maxCount 1 ;
+      sh:name "media type" ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:temporalCoverage ;
+      sh:class ids:TemporalEntity ;
+      sh:name "temporal coverage" ;
+      sh:node ap15:TemporalCoverageShape ;
+    ] ;
+.
+
+ap15:TemporalCoverageShape
+  a rdfs:Class ;
+  a sh:NodeShape ;
+  sh:targetClass ids:Interval;
+  rdfs:label "Temporal coverage shape" ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:begin ;
+      sh:class ids:Instant;
+      sh:maxCount 1 ;
+      sh:minCount 1 ;
+      sh:name "begin" ;
+      sh:node ap15:InstantShape ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:end ;
+      sh:class ids:Instant ;
+      sh:maxCount 1 ;
+      sh:name "end" ;
+      sh:node ap15:InstantShape ;
+    ] ;
+.
+ap15:TextResourceShape
+    a sh:NodeShape;
+    sh:targetClass ids:TextResource;
+    sh:property [
+                    a sh:PropertyShape ;
+                    sh:path ids:representation ;
+                    sh:class ids:TextRepresentation ;
+                ] ;
+
+    sh:property [
+                    a sh:PropertyShape ;
+                    sh:path ids:defaultRepresentation ;
+                    sh:class ids:ImageRepresentation ;
+                ] ;
+.
+
+ids:PrefixDeclaration
+  a sh:PrefixDeclaration ;
+  sh:namespace "https://w3id.org/idsa/core/"^^xsd:anyURI ;
+  sh:prefix "ids" ;
+.

--- a/examples-SHACL-validations/extendedValidations/extendedExampleResource-ExternalReferences.ttl
+++ b/examples-SHACL-validations/extendedValidations/extendedExampleResource-ExternalReferences.ttl
@@ -1,0 +1,105 @@
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix ids: <https://w3id.org/idsa/core/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+@prefix data3: <https://aastat.gov.de/connector/conn3/data3/> .
+@prefix idsc: <https://w3id.org/idsa/code/> .
+@prefix part1: <https://im.internationaldataspaces.org/participant/part1> .
+@prefix freq: <http://purl.org/cld/freq/> .
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+
+data3:
+  a <https://w3id.org/idsa/core/TextResource> ;
+  dct:language idsc:EN ;
+  dct:temporal [
+    a <https://w3id.org/idsa/core/Interval> ;
+    time:hasBeginning [
+      a time:Instant ;
+      ids:dateTime "2001-01-01T12:00:00-05:00"^^xsd:dateTime
+    ] ;
+    time:hasEnd [
+      a time:Instant ;
+      ids:dateTime "2017-12-31T12:00:00-05:00"^^xsd:dateTime
+    ]
+  ] ;
+  ids:contractOffer data3:offer;                   
+  dct:description "Detailed traffic analysis report based on European highway statistics data 2000 - 2017."@en ;
+  dct:keyword "report"^^xsd:string, "highway"^^xsd:string, "statistics"^^xsd:string, "Europe"^^xsd:string ;
+  dct:language idsc:EN ;
+  ids:representation [
+        a ids:TextRepresentation ;
+        dcat:mediaType <https://www.iana.org/assignments/media-types/application/pdf> ;
+        ids:instance data3:report_pdf ;
+        dct:accrualPeriodicity [ a ids:Frequency ;
+                                rdf:value  freq:irregular ;
+                                rdfs:label "irregular / dynamic" ; ]
+    ] ;
+    ids:representation [
+        a ids:TextRepresentation ;
+        dct:accrualPeriodicity [ a ids:Frequency ;
+                                rdf:value  freq:regular ;
+                                rdfs:label "regular / dynamic" ; ];
+        dcat:mediaType <https://www.iana.org/assignments/media-types/application/msword> ;
+        ids:instance data3:report_doc ;
+    ] ;
+  ids:resourceEndpoint [
+    a ids:ConnectorEndpoint ;
+    ids:accessURL <https://connector.aastat.gov.de/reports/Highway_traffic_statistics.pdf> ;
+    ids:endpointArtifact data3:report_pdf
+  ], [
+    a ids:ConnectorEndpoint ;
+    ids:accessURL <https://connector.aastat.gov.de/reports/Highway_traffic_statistics.doc> ;
+    ids:endpointArtifact data3:report_doc
+  ] ;
+  dct:title "European highway statistics - traffic report"@en .
+
+data3:offer
+  a ids:ContractOffer ;
+  ids:contractStart "2021-10-10T12:00:00-05:00"^^xsd:dateTime ;
+  ids:contractEnd      "2022-06-01T12:00:00-05:00"^^xsd:dateTime ;
+  ids:provider         <http://iml.fraunhofer.de> ;
+  ids:contractDocument data3:;
+  odrl:permission [
+    a odrl:Permission ;
+    odrl:action  data3:action;
+    ids:target data3: ;
+    odrl:assigner <https://im.internationaldataspaces.org/participant/part1> ;
+    odrl:assignee <https://im.internationaldataspaces.org/participant/part2> ;
+    odrl:constraint data3:constraint ].
+
+data3:report_pdf
+  a ids:Artifact ;
+  ids:byteSize "28923491"^^xsd:integer ;
+  ids:duration "13.456"^^xsd:decimal ;
+  ids:checkSum "11011010"^^xsd:string;
+  dct:created "2018-06-18T12:00:00.000+02:00"^^xsd:dateTimeStamp ;
+  ids:fileName "Highway_traffic_statistics.pdf"^^xsd:string .
+
+data3:report_doc
+    a ids:Artifact ;
+    ids:byteSize "28923491"^^xsd:integer ;
+    ids:duration "1.256"^^xsd:decimal ;
+    ids:checkSum "11111000"^^xsd:string;
+    ids:fileName "Highway_traffic_statistics.doc" ;
+    dct:created "2018-06-18T12:00:00.000+02:00"^^xsd:dateTimeStamp ;
+    .
+
+idsc:READ a data3:action .
+data3:action a odrl:Action .
+
+<https://www.iana.org/assignments/media-types/application/pdf> a ids:IANAMediaType .
+<https://www.iana.org/assignments/media-types/application/msword> a ids:IANAMediaType .
+
+data3:constraint
+      a odrl:Constraint ;
+      ids:leftOperand idsc:DELAY ;
+      ids:operator idsc:LONGER ;
+      ids:rightOperand "PT20M"^^xsd:duration .
+
+idsc:EN a ids:Language .
+
+ids:IANAMediaType rdfs:subClassOf dct:MediaType .

--- a/examples-SHACL-validations/extendedValidations/extendedExampleResource-LocalReferences.ttl
+++ b/examples-SHACL-validations/extendedValidations/extendedExampleResource-LocalReferences.ttl
@@ -1,0 +1,93 @@
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix ids: <https://w3id.org/idsa/core/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+@prefix data3: <https://aastat.gov.de/connector/conn3/data3/> .
+@prefix idsc: <https://w3id.org/idsa/code/> .
+@prefix part1: <https://im.internationaldataspaces.org/participant/part1> .
+@prefix freq: <http://purl.org/cld/freq/> .
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+data3:
+  a <https://w3id.org/idsa/core/TextResource> ;
+  dct:temporal [
+    a <https://w3id.org/idsa/core/Interval> ;
+    ids:begin [
+      a ids:Instant ;
+      ids:dateTime "2001-01-01T12:00:00-05:00"^^xsd:dateTime
+    ] ;
+    ids:end [
+      a ids:Instant ;
+      ids:dateTime "2017-12-31T12:00:00-05:00"^^xsd:dateTime
+    ]
+  ] ;
+  ids:contractOffer data3:offer;                   
+  ids:description "Detailed traffic analysis report based on European highway statistics data 2000 - 2017."@en ;
+  ids:keyword "report"^^xsd:string, "highway"^^xsd:string, "statistics"^^xsd:string, "Europe"^^xsd:string ;
+  ids:language idsc:EN ;
+  ids:representation [
+        a ids:TextRepresentation ;
+        ids:mediaType <https://www.iana.org/assignments/media-types/application/pdf> ;
+        ids:instance data3:report_pdf ;
+        ids:accrualPeriodicity [ a ids:Frequency ;
+                                rdf:value  freq:irregular ;
+                                rdfs:label "irregular / dynamic" ; ]
+    ] ;
+    ids:representation [
+        a ids:TextRepresentation ;
+        ids:mediaType <https://www.iana.org/assignments/media-types/application/msword> ;
+        ids:instance data3:report_doc ;
+        ids:accrualPeriodicity [ a ids:Frequency ;
+                                rdf:value  freq:regular ;
+                                rdfs:label "regular / dynamic" ; ]
+    ] ;
+  ids:resourceEndpoint [
+    a ids:ConnectorEndpoint ;
+    ids:accessURL <https://connector.aastat.gov.de/reports/Highway_traffic_statistics.pdf> ;
+    ids:endpointArtifact data3:report_pdf
+  ], [
+    a ids:ConnectorEndpoint ;
+    ids:accessURL <https://connector.aastat.gov.de/reports/Highway_traffic_statistics.doc> ;
+    ids:endpointArtifact data3:report_doc
+  ] ;
+  ids:title "European highway statistics - traffic report"@en .
+
+data3:offer
+  a ids:ContractOffer ;
+  ids:contractStart "2021-10-10T12:00:00-05:00"^^xsd:dateTime ;
+  ids:contractEnd      "2022-06-01T12:00:00-05:00"^^xsd:dateTime ;
+  ids:provider         <http://iml.fraunhofer.de> ;
+  ids:contractDocument data3:;
+  ids:permission [
+    a ids:Permission ;
+    ids:action     idsc:READ;
+    ids:target data3: ;
+    ids:assigner <https://im.internationaldataspaces.org/participant/part1> ;
+    ids:assignee <https://im.internationaldataspaces.org/participant/part2> ;
+    ids:constraint [
+      a ids:AbstractConstraint ;
+      ids:leftOperand idsc:DELAY ;
+      ids:operator idsc:LONGER ;
+      ids:rightOperand "PT20M"^^xsd:duration
+    ] ;
+  ] .
+
+data3:report_pdf
+  a ids:Artifact ;
+  ids:byteSize "28923491"^^xsd:integer ;
+  ids:creationDate "2018-06-18T12:00:00.000+02:00"^^xsd:dateTimeStamp ;
+  ids:checkSum "11011010"^^xsd:string;
+  ids:fileName "Highway_traffic_statistics.pdf"^^xsd:string .
+
+data3:report_doc
+    a ids:Artifact ;
+    ids:byteSize "28923491"^^xsd:integer ;
+    ids:fileName "Highway_traffic_statistics.doc" ;
+    ids:creationDate "2018-06-18T12:00:00.000+02:00"^^xsd:dateTimeStamp ;
+    ids:checkSum "11111000"^^xsd:string;
+    .
+
+<https://www.iana.org/assignments/media-types/application/pdf> a ids:IANAMediaType .
+<https://www.iana.org/assignments/media-types/application/msword> a ids:IANAMediaType .
+

--- a/examples-SHACL-validations/extendedValidations/extendedIDSValidation-LocalReferences.ttl
+++ b/examples-SHACL-validations/extendedValidations/extendedIDSValidation-LocalReferences.ttl
@@ -1,0 +1,425 @@
+# baseURI: http://fit.fraunhofer.de/ap15/constraints
+# imports: http://datashapes.org/dash
+# imports: http://purl.org/dc/elements/1.1/
+# imports: http://purl.org/dc/terms/
+# prefix: ap15
+
+#Basic IDS validation, using validations specificed in the main brach of the IDS Infomodel (before refactor to reference external specifications) https://github.com/International-Data-Spaces-Association/InformationModel/tree/main/testing
+
+@prefix ap15: <http://fit.fraunhofer.de/ap15/constraints#> .
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ids: <https://w3id.org/idsa/core/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix p1: <http://xmlns.com/foaf/0.1/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://fit.fraunhofer.de/ap15/constraints>
+  a owl:Ontology ;
+  owl:imports <http://datashapes.org/dash> ;
+  owl:imports <http://purl.org/dc/elements/1.1/> ;
+  owl:imports <http://purl.org/dc/terms/> ;
+  owl:versionInfo "Created with TopBraid Composer" ;
+  sh:declare ids:PrefixDeclaration ;
+.
+ap15:ConnectorEndpointShape
+  a rdfs:Class ;
+  a sh:NodeShape ;
+sh:targetClass ids:ConnectorEndpoint ;
+  rdfs:label "Connector endpoint shape" ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:accessURL ;
+      sh:nodeKind sh:IRI ;
+      sh:minCount 1 ;
+      sh:maxCount 1;
+      sh:name "access URL" ;
+    ] ;
+sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:endpointArtifact ;
+		sh:class ids:Artifact ;
+		sh:maxCount 1 ;
+        sh:minCount 1;
+	] ;
+.
+
+ap15:ArtifactShape
+	a sh:NodeShape ;
+	sh:targetClass ids:Artifact ;
+
+	sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:byteSize ;
+		sh:datatype xsd:integer ;
+        sh:minInclusive 0 ;
+		sh:maxCount 1 ;
+	] ;
+
+
+	sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:fileName ;
+		sh:datatype xsd:string ;
+		sh:maxCount 1 ;
+        sh:minCount 1;
+	] ;
+
+	sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:creationDate ;
+		sh:datatype xsd:dateTimeStamp ;
+		sh:maxCount 1 ;
+        sh:minCount 1;
+	] ;
+
+	sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:artifactParameterization ;
+		sh:class ids:ParameterAssignment ;
+	] ;
+
+	sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:checkSum ;
+		sh:datatype xsd:string ;
+		sh:maxCount 1 ;
+        sh:minCount 1;
+	] ;
+
+	sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:duration ;
+		sh:datatype xsd:decimal ;
+		sh:maxCount 1 ;
+	] .
+
+
+ap15:ResourceShape
+  a rdfs:Class ;
+  a sh:NodeShape ;
+  rdfs:label "Resource shape" ;
+  sh:targetClass ids:Resource;
+  sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:description ;
+        sh:minCount 1;
+		sh:or (
+            [
+                sh:datatype xsd:string ;
+			]
+			[
+                sh:datatype rdf:langString ;
+            ]
+            );
+	] ;
+sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:title ;
+        sh:minCount 1 ;
+        sh:minCount 1;
+    sh:or (
+            [
+                sh:datatype xsd:string ;
+			]
+			[
+                sh:datatype rdf:langString ;
+            ]
+            );
+	] ;
+
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:created ;
+      sh:datatype xsd:dateTime ;
+      sh:maxCount 1 ;
+      sh:minCount 1;
+      sh:name "created" ;
+    ] ;
+	sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:keyword ;
+        sh:minCount 1;
+        sh:maxCount 5;
+		sh:or (
+            [
+                sh:datatype xsd:string ;
+			]
+			[
+                sh:datatype rdf:langString ;
+            ]
+    );
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:modified ;
+      sh:datatype xsd:dateTime ;
+      sh:maxCount 1 ;
+      sh:minCount 1;
+      sh:name "modified" ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:publisher ;
+      sh:nodeKind sh:IRI ;
+      sh:maxCount 1 ;
+      sh:minCount 1;
+      sh:name "publisher" ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:resourceEndpoint ;
+      sh:name "resource endpoint" ;
+      sh:minCount 1;
+      sh:node ap15:ConnectorEndpointShape ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:resourcePart ;
+      sh:class ids:Resource ;
+      sh:minCount 1;
+      sh:name "resource part" ;
+      sh:node ap15:ResourceShape ;
+    ] ;
+  sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:resourceInterface ;
+		sh:class ids:Interface ;
+	] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:sovereign ;
+      sh:nodeKind sh:IRI ;
+      sh:maxCount 1 ;
+      sh:name "sovereign" ;
+    ] ;
+   sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:contractOffer ;
+        sh:minCount 1;
+		sh:node ap15:ContractOfferShape ;
+	] ;
+    sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:sample ;
+		sh:class ids:Resource ;
+	] ;
+    sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:variant ;
+		sh:class ids:Resource ;
+		sh:maxCount 1 ;
+	];
+.
+
+ap15:ContractOfferShape
+  a rdfs:Class ;
+  a sh:NodeShape ;
+  sh:targetClass ids:ContractOffer;
+  rdfs:label "Contract offer shape" ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:contractDocument ;
+      sh:class ids:TextResource ;
+      sh:name "contract document" ;
+      sh:maxCount 1 ;
+      sh:minCount 1;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:contractEnd ;
+      sh:datatype xsd:dateTime ;
+      sh:maxCount 1 ;
+      sh:name "contract end" ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:contractStart ;
+      sh:datatype xsd:dateTime ;
+      sh:minCount 1 ;
+      sh:maxCount 1 ;
+      sh:name "contract start" ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:permission ;
+      sh:class ids:Permission ;
+      sh:name "permission" ;
+      sh:node ap15:PermissionShape ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:provider ;
+      sh:nodeKind sh:IRI ;
+      sh:pattern "^(?:(http(s)?|idscp|(s)?ftp))";
+      sh:maxCount 1 ;
+      sh:minCount 1;
+      sh:name "provider" ;
+    ] ;
+.
+ap15:InstantShape
+  a rdfs:Class ;
+  a sh:NodeShape ;
+  sh:targetClass ids:Instant;
+  rdfs:label "Instant shape" ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:dateTime ;
+      sh:datatype xsd:dateTime ;
+      sh:maxCount 1 ;
+      sh:minCount 1 ;
+      sh:name "date time" ;
+    ] ;
+.
+ap15:PermissionShape
+  a rdfs:Class ;
+  a sh:NodeShape ;
+  sh:targetClass ids:Permission;
+  rdfs:label "Permission shape" ;
+  sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:preDuty ;
+		sh:class ids:Duty ;
+	] ;
+
+	sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:postDuty ;
+		sh:class ids:Duty ;
+	] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:action ;
+      sh:minCount 1 ;
+      sh:name "action" ;
+    ] ;
+    sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:assignee ;
+		sh:or (
+      [ sh:nodeKind sh:IRI ; ]
+			[ sh:class ids:Participant ; ]
+    );
+		sh:minCount 1 ;
+	] ;
+sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:assigner ;
+		sh:or (
+      [ sh:nodeKind sh:IRI ; ]
+			[ sh:class ids:Participant ; ]
+    );
+		sh:minCount 1 ;
+	] ;
+sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:target ;
+		sh:or (
+      [ sh:nodeKind sh:IRI ; ]
+			[ sh:class ids:Asset ; ]
+    );
+		sh:maxCount 1 ;
+	] ;
+sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:assetRefinement ;
+		sh:class ids:AbstractConstraint ;
+		sh:maxCount 1 ;
+	] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:constraint ;
+      sh:class ids:AbstractConstraint ;
+      sh:name "constraint" ;
+    ] ;
+.
+ap15:RepresentationShape
+  a rdfs:Class ;
+  a sh:NodeShape ;
+  sh:targetClass ids:TextRepresentation;
+  rdfs:label "Representation shape" ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:accrualPeriodicity ;
+      sh:class ids:Frequency ;
+      sh:maxCount 1 ;
+      sh:minCount 1;
+      sh:name "accrual periodicity" ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:dataTypeSchema ;
+      sh:class ids:Resource ;
+      sh:maxCount 1 ;
+      sh:name "data type schema" ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:mediaType ;
+      sh:or (
+            [
+                sh:class ids:MediaType ;
+			]
+			[
+                sh:class ids:IANAMediaType ;
+            ]
+            );
+      sh:maxCount 1 ;
+      sh:name "media type" ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:temporalCoverage ;
+      sh:class ids:TemporalEntity ;
+      sh:name "temporal coverage" ;
+      sh:node ap15:TemporalCoverageShape ;
+    ] ;
+.
+
+ap15:TemporalCoverageShape
+  a rdfs:Class ;
+  a sh:NodeShape ;
+  sh:targetClass ids:Interval;
+  rdfs:label "Temporal coverage shape" ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:begin ;
+      sh:class ids:Instant;
+      sh:maxCount 1 ;
+      sh:minCount 1 ;
+      sh:name "begin" ;
+      sh:node ap15:InstantShape ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:end ;
+      sh:class ids:Instant ;
+      sh:maxCount 1 ;
+      sh:name "end" ;
+      sh:node ap15:InstantShape ;
+    ] ;
+.
+ap15:TextResourceShape
+    a sh:NodeShape;
+    sh:targetClass ids:TextResource;
+    sh:property [
+                    a sh:PropertyShape ;
+                    sh:path ids:representation ;
+                    sh:class ids:TextRepresentation ;
+                ] ;
+
+    sh:property [
+                    a sh:PropertyShape ;
+                    sh:path ids:defaultRepresentation ;
+                    sh:class ids:ImageRepresentation ;
+                ] ;
+.
+
+ids:PrefixDeclaration
+  a sh:PrefixDeclaration ;
+  sh:namespace "https://w3id.org/idsa/core/"^^xsd:anyURI ;
+  sh:prefix "ids" ;
+.

--- a/examples-SHACL-validations/extendedValidations/extendedValidation-ExternalReferences.ttl
+++ b/examples-SHACL-validations/extendedValidations/extendedValidation-ExternalReferences.ttl
@@ -1,0 +1,421 @@
+# baseURI: http://fit.fraunhofer.de/ap15/constraints
+# imports: http://datashapes.org/dash
+# imports: http://purl.org/dc/elements/1.1/
+# imports: http://purl.org/dc/terms/
+# prefix: ap15
+
+#Basic IDS validation, using validations specificed in the develop brach of the IDS Infomodel (after refactor to reference external specifications) https://github.com/International-Data-Spaces-Association/InformationModel/tree/develop/testing
+
+@prefix ap15: <http://fit.fraunhofer.de/ap15/constraints#> .
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ids: <https://w3id.org/idsa/core/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix p1: <http://xmlns.com/foaf/0.1/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+
+<http://fit.fraunhofer.de/ap15/constraints>
+  a owl:Ontology ;
+  owl:imports <http://datashapes.org/dash> ;
+  owl:imports <http://purl.org/dc/elements/1.1/> ;
+  owl:imports <http://purl.org/dc/terms/> ;
+  owl:versionInfo "Created with TopBraid Composer" ;
+  sh:declare ids:PrefixDeclaration ;
+.
+ap15:ConnectorEndpointShape
+  a rdfs:Class ;
+  a sh:NodeShape ;
+sh:targetClass ids:ConnectorEndpoint ;
+  rdfs:label "Connector endpoint shape" ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:accessURL ;
+      sh:nodeKind sh:IRI ;
+      sh:minCount 1 ;
+      sh:maxCount 1;
+      sh:name "access URL" ;
+    ] ;
+sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:endpointArtifact ;
+		sh:class ids:Artifact ;
+		sh:maxCount 1 ;
+        sh:minCount 1 ;
+	] ;
+.
+
+ap15:ArtifactShape
+	a sh:NodeShape ;
+	sh:targetClass ids:Artifact ;
+
+	sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:byteSize ;
+		sh:datatype xsd:integer ;
+        sh:minInclusive 0 ;
+		sh:maxCount 1 ;
+        sh:minCount 1 ;
+	] ;
+
+
+	sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:fileName ;
+		sh:datatype xsd:string ;
+		sh:maxCount 1 ;
+        sh:minCount 1 ;
+	] ;
+
+	sh:property [
+		a sh:PropertyShape ;
+		sh:path dct:created ;
+		sh:datatype xsd:dateTimeStamp ;
+		sh:maxCount 1 ;
+        sh:minCount 1 ;
+	] ;
+
+	sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:checkSum ;
+		sh:datatype xsd:string ;
+		sh:maxCount 1 ;
+        sh:minCount 1 ;
+	] ;
+
+	sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:duration ;
+		sh:datatype xsd:decimal ;
+		sh:maxCount 1 ;
+        sh:minCount 1 ;
+	] .
+
+
+ap15:ResourceShape
+  a rdfs:Class ;
+  a sh:NodeShape ;
+  rdfs:label "Resource shape" ;
+  sh:targetClass ids:Resource;
+  sh:property [
+		a sh:PropertyShape ;
+		sh:path dct:description ;
+        sh:minCount 1;
+		sh:or (
+            [
+                sh:datatype xsd:string ;
+			]
+			[
+                sh:datatype rdf:langString ;
+            ]
+            );
+	] ;
+sh:property [
+		a sh:PropertyShape ;
+		sh:path dct:title ;
+        sh:minCount 1 ;
+        sh:maxCount 1;
+    sh:or (
+            [
+                sh:datatype xsd:string ;
+			]
+			[
+                sh:datatype rdf:langString ;
+            ]
+            );
+	] ;
+
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path dct:issued ;
+      sh:datatype xsd:dateTime ;
+      sh:maxCount 1 ;
+      sh:minCount 1 ;
+      sh:name "created" ;
+    ] ;
+	sh:property [
+		a sh:PropertyShape ;
+		sh:path dcat:keyword ;
+        sh:minCount 1;
+        sh:maxCount 5;
+		sh:or (
+            [
+                sh:datatype xsd:string ;
+			]
+			[
+                sh:datatype rdf:langString ;
+            ]
+    );
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path dct:modified ;
+      sh:datatype xsd:dateTime ;
+      sh:maxCount 1 ;
+      sh:minCount 1 ;
+      sh:name "modified" ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path dct:publisher ;
+      sh:or (
+	    [ sh:class foaf:Agent ; sh:order 1 ; ]
+	    [ sh:nodeKind sh:IRI ; sh:order 2 ; ]
+		) ;
+      sh:maxCount 1 ;
+      sh:minCount 1 ;
+      sh:name "publisher" ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:resourceEndpoint ;
+      sh:name "resource endpoint" ;
+      sh:minCount 1 ;
+      sh:node ap15:ConnectorEndpointShape ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:resourcePart ;
+      sh:minCount 1 ;
+      sh:class ids:Resource ;
+      sh:name "resource part" ;
+      sh:node ap15:ResourceShape ;
+    ] ;
+  sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:resourceInterface ;
+		sh:class ids:Interface ;
+	] ;
+  sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:sovereign ;
+		sh:or (
+	    [ sh:class foaf:Agent ; sh:order 1 ; ]
+	    [ sh:nodeKind sh:IRI ; sh:order 2 ; ]
+		) ;
+		sh:maxCount 1 ;
+	] ;
+   sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:contractOffer ;
+        sh:minCount 1;
+		sh:node ap15:ContractOfferShape ;
+	] ;
+    sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:sample ;
+		sh:class ids:Resource ;
+	] ;
+    sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:variant ;
+		sh:class ids:Resource ;
+		sh:maxCount 1 ;
+	];
+.
+
+ap15:ContractOfferShape
+  a rdfs:Class ;
+  a sh:NodeShape ;
+  sh:targetClass ids:ContractOffer;
+  rdfs:label "Contract offer shape" ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:contractDocument ;
+      sh:class ids:TextResource ;
+      sh:name "contract document" ;
+      sh:minCount 1 ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:contractEnd ;
+      sh:datatype xsd:dateTime ;
+      sh:maxCount 1 ;
+      sh:name "contract end" ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:contractStart ;
+      sh:datatype xsd:dateTime ;
+      sh:minCount 1 ;
+      sh:maxCount 1 ;
+      sh:name "contract start" ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path odrl:permission ;
+      sh:class odrl:Permission ;
+      sh:name "permission" ;
+      sh:node ap15:PermissionShape ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:provider ;
+      sh:nodeKind sh:IRI ;
+      sh:pattern "^(?:(http(s)?|idscp|(s)?ftp))";
+      sh:maxCount 1 ;
+      sh:minCount 1 ;
+      sh:name "provider" ;
+    ] ;
+.
+ap15:InstantShape
+  a rdfs:Class ;
+  a sh:NodeShape ;
+  sh:targetClass time:Instant;
+  rdfs:label "Instant shape" ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path time:inXSDDateTimeStamp ;
+      sh:datatype xsd:dateTimeStamp ;
+      sh:maxCount 1 ;
+      sh:name "date time" ;
+    ] ;
+.
+ap15:PermissionShape
+  a rdfs:Class ;
+  a sh:NodeShape ;
+  sh:targetClass odrl:Permission;
+  rdfs:label "Permission shape" ;
+  sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:preDuty ;
+		sh:class odrl:Duty ;
+	] ;
+
+	sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:postDuty ;
+		sh:class odrl:Duty ;
+	] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path odrl:action ;
+      sh:class odrl:Action ;
+      sh:minCount 1 ;
+      sh:name "action" ;
+    ] ;
+    sh:property [
+		a sh:PropertyShape ;
+		sh:path odrl:assignee ;
+        sh:nodeKind sh:IRI ;
+		sh:minCount 1 ;
+	] ;
+sh:property [
+		a sh:PropertyShape ;
+		sh:path odrl:assigner ;
+        sh:nodeKind sh:IRI ; 
+		sh:minCount 1 ;
+	] ;
+sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:target ;
+        sh:nodeKind sh:IRI ;
+		sh:maxCount 1 ;
+	] ;
+sh:property [
+		a sh:PropertyShape ;
+		sh:path odrl:refinement ;
+		sh:class odrl:Constraint ;
+		sh:maxCount 1 ;
+	] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path odrl:constraint ;
+      sh:class odrl:Constraint ;
+      sh:name "constraint" ;
+    ] ;
+.
+ap15:RepresentationShape
+  a rdfs:Class ;
+  a sh:NodeShape ;
+  sh:targetClass ids:TextRepresentation;
+  rdfs:label "Representation shape" ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path dct:accrualPeriodicity ;
+      sh:class ids:Frequency ;
+      sh:maxCount 1 ;
+      sh:minCount 1 ;
+      sh:name "accrual periodicity" ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:dataTypeSchema ;
+      sh:class ids:Resource ;
+      sh:maxCount 1 ;
+      sh:name "data type schema" ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path dcat:mediaType ;
+      sh:class dct:MediaType ;
+      sh:maxCount 1 ;
+      sh:minCount 1 ;
+      sh:name "media type" ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path dct:temporal ;
+      sh:class time:TemporalEntity ;
+      sh:name "temporal coverage" ;
+      sh:node ap15:TemporalCoverageShape ;
+    ] ;
+.
+
+ap15:TemporalCoverageShape
+  a rdfs:Class ;
+  a sh:NodeShape ;
+  sh:targetClass time:Interval;
+  rdfs:label "Temporal coverage shape" ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path time:hasBeginning ;
+      sh:class time:Instant;
+      sh:maxCount 1 ;
+      sh:minCount 1 ;
+      sh:name "begin" ;
+      sh:node ap15:InstantShape ;
+    ] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path time:hasEnd ;
+      sh:class time:Instant ;
+      sh:maxCount 1 ;
+      sh:name "end" ;
+      sh:node ap15:InstantShape ;
+    ] ;
+.
+ap15:TextResourceShape
+    a sh:NodeShape;
+    sh:targetClass ids:TextResource;
+    sh:property [
+                    a sh:PropertyShape ;
+                    sh:path ids:representation ;
+                    sh:class ids:TextRepresentation ;
+                ] ;
+
+    sh:property [
+                    a sh:PropertyShape ;
+                    sh:path ids:defaultRepresentation ;
+                    sh:class ids:TextRepresentation ;
+                ] ;
+    sh:property [
+		a sh:PropertyShape ;
+		sh:path dct:language ;
+		sh:class ids:Language ;
+        sh:minCount 1;
+	] ;
+
+.
+
+ids:PrefixDeclaration
+  a sh:PrefixDeclaration ;
+  sh:namespace "https://w3id.org/idsa/core/"^^xsd:anyURI ;
+  sh:prefix "ids" ;
+.


### PR DESCRIPTION
- basicIDSValidations contains the basic validations against the models defined in the IDS infomodel. There are two variants: one covers only local reference (prefix: ids), the other covers external references (prefixes: dcat, dct, time, etc.)

- extendedValidations contains the extended validations by including minCount 1 for some properties

@lcomet FYI I merged your contribution to the main repository.